### PR TITLE
feat: 리밸런스 리스너가 함께 설정된 Consumer

### DIFF
--- a/src/main/java/com/moonz/study/consumer/ConsumerWithRebalanceListener.java
+++ b/src/main/java/com/moonz/study/consumer/ConsumerWithRebalanceListener.java
@@ -1,0 +1,50 @@
+package com.moonz.study.consumer;
+
+import com.moonz.study.rebalancelistener.RebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * 구현한 RebalanceListener 를 전달하여, 리밸런싱이 발생할 때 전/후에 호출되도록 하였다.
+ */
+public class ConsumerWithRebalanceListener {
+    private static final Logger logger = LoggerFactory.getLogger(ConsumerWithRebalanceListener.class);
+    private static final String BOOTSTRAP_SERVERS = "my-kafka:9092";
+    private static final String TOPIC_NAME = "test";
+    private static final String GROUP_ID = "test-group";
+
+    /**
+     * 브로커에 데이터가 저장되면 이를 가져와서 로깅하는 로직 작성.
+     */
+    public static void main(String[] args) {
+
+        Properties configs = new Properties();
+        configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(configs);
+
+        // 구독을 할 때 리밸런스 리스너를 전달한다.
+        consumer.subscribe(List.of(TOPIC_NAME), new RebalanceListener());
+
+        while (true) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(1));
+            logger.info("records: {}", records);
+            for (ConsumerRecord<String, String> record : records) {
+                logger.info("record : {}", record);
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/moonz/study/rebalancelistener/RebalanceListener.java
+++ b/src/main/java/com/moonz/study/rebalancelistener/RebalanceListener.java
@@ -1,0 +1,21 @@
+package com.moonz.study.rebalancelistener;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class RebalanceListener implements ConsumerRebalanceListener {
+    private final static Logger logger = LoggerFactory.getLogger(RebalanceListener.class);
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+        logger.warn("리밸런싱이 발생하기 직전에 파티션들이 어떻게 할당되어있는지 상태 확인 : {}", partitions);
+    }
+
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+        logger.warn("리밸런스가 끝나서 파티션들이 할당(assigned)되었다. : {}", partitions);
+    }
+}


### PR DESCRIPTION
리밸런스 발생을 감지하기 위해 카프카 라이브러리 (java)는 `ConsumerRebalanceListener` 인터페이스를 지원한다.

이 인터페이스를 구현하면, `onPartitionAssigned()`, `onPartitionRevoked()` 메서드를 구현하게 된다.
- `onPartitionAssigned()` : 리밸런스가 끝난 뒤에 파티션이 할당이 완료되면, 호출되는 메서드로, 관련 정보들을 받을 수 있다.
- `onPartitionRevoked()` : 리밸런스가 시작되기 직전에 호출되는 메서드로, 리밸런스가 시작하기 직전에 마지막으로 처리한 레코드를 커밋하는 로직을 작성할 수 있다. 

### 실습.
컨슈머 그룹 1개를 띄우고, 그다음 컨슈머 그룹을 1개 더 띄웠다.
첫번째 컨슈머 그룹이 test-0,1,2,3,4 파티션이,
두번째 컨슈머 그룹이 test-5,6,7,8,9 파티션이 할당되어 있었는데
첫번째 컨슈머 그룹이 죽었더니 두번째 컨슈머 그룹에게 파티션이 모두 할당되었다.
```
com.moonz.study.rebalancelistener.RebalanceListener - 리밸런싱이 발생하기 직전에 파티션들이 어떻게 할당되어있는지 상태 확인 : [test-5, test-7, test-6, test-9, test-8]
com.moonz.study.rebalancelistener.RebalanceListener - 리밸런스가 끝나서 파티션들이 할당(assigned)되었다. : [test-1, test-0, test-3, test-2, test-5, test-4, test-7, test-6, test-9, test-8]
```


